### PR TITLE
Hide portfolio section in resume

### DIFF
--- a/resume.md
+++ b/resume.md
@@ -36,6 +36,7 @@ Software Developer with 4 years of experience building high-performance, user-fr
 - Collaborated with designers to implement **pixel-perfect** designs and ensure consistent **user experiences**.
 - Communicated directly with clients to gather requirements and deliver tailored, scalable solutions.
 
+<!--
 ## Portfolio
 
  - [Prirodou Samosebou](https://prirodou.samosebou.cz/)
@@ -45,6 +46,7 @@ Software Developer with 4 years of experience building high-performance, user-fr
  - [Abdul Latif Jameel Enterprises](https://alj-web.vercel.app/en)
  - [Udoban Dom](https://www.udobandom.com)
  - [Villa Hana](https://villahana-croatia.com/)
+-->
 
 ## Education
 


### PR DESCRIPTION
## Summary
- hide the portfolio section within the resume markdown so it is no longer rendered on the site

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ee92f5af588331aeaa6f568133989e